### PR TITLE
support %w print verb

### DIFF
--- a/source/languages/go/original.tmLanguage.json
+++ b/source/languages/go/original.tmLanguage.json
@@ -587,7 +587,7 @@
         "string_placeholder": {
             "patterns": [
                 {
-                    "match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGsp]",
+                    "match": "%(\\[\\d+\\])?([\\+#\\-0\\x20]{,2}((\\d+|\\*)?(\\.?(\\d+|\\*|(\\[\\d+\\])\\*?)?(\\[\\d+\\])?)?))?[vT%tbcdoqxXUbeEfFgGspw]",
                     "name": "constant.other.placeholder.go"
                 }
             ]


### PR DESCRIPTION
`%w` added as of go1.13. Functionally identical to `%v`, but implicitly wraps errors.

You cheeky monkey.