### PR TITLE
Remove invalid receive/send channel patterns

### DIFF
--- a/source/original.tmLanguage.json
+++ b/source/original.tmLanguage.json
@@ -58,24 +58,6 @@
             ]
         },
         {
-            "comment": "Syntax error receiving channels",
-            "match": "<\\-([\\t ]+)chan\\b",
-            "captures": {
-                "1": {
-                    "name": "invalid.illegal.receive-channel.go"
-                }
-            }
-        },
-        {
-            "comment": "Syntax error sending channels",
-            "match": "\\bchan([\\t ]+)<-",
-            "captures": {
-                "1": {
-                    "name": "invalid.illegal.send-channel.go"
-                }
-            }
-        },
-        {
             "comment": "Syntax error using slices",
             "match": "\\[\\](\\s+)",
             "captures": {


### PR DESCRIPTION
I hope this isn't disqualifying, but I didn't follow the contributing guidelines: installing Ruby felt a bit extreme for my proposed changes. I did find go.tmLanguage.json in the VSCode source, and made these changes there to test.

I came across these patterns after noticing a highlighting bug when defining a "send channel of channels." 

<img width="639" alt="receive-channel" src="https://user-images.githubusercontent.com/4529340/142581690-c04e25af-26b3-4985-b26d-aaab8631015f.png">

<img width="612" alt="send-channel" src="https://user-images.githubusercontent.com/4529340/142581681-4868697c-1626-40ef-a542-64e0352107aa.png">



The screenshotted file is unsaved because, upon saving, the second line becomes auto-formatted to match the first. Here I learned for the first time, after checking the [channel section of the spec](https://golang.org/ref/spec#Channel_types), that the receive/send/bidirectional qualification is determined by left associativity rather than prefix/suffix. These two patterns that I recommend removing seem to suggest the opposite (prefix/suffix, must be adjacent). You can see in this [Go Playground example](https://play.golang.org/p/wCfzAGA5ejL) that spacing around the arrows doesn't matter.

Given this rule, "chan <-chan" is super confusing, but that's a separate issue addressed by the formatter.

In summary, my proposal to remove these two channel patterns was prompted by a syntax highlighting bug, but after looking into it, the patterns seem to not be in line with the spec.






